### PR TITLE
svelte-local-storage-store as peerDependecies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
 		"dist"
 	],
 	"peerDependencies": {
-		"svelte": "^3.54.0"
+		"svelte": "^3.54.0",
+		"svelte-local-storage-store": "^0.4.0"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.28.1",
@@ -60,8 +61,5 @@
 	},
 	"svelte": "./dist/index.js",
 	"types": "./dist/index.d.ts",
-	"type": "module",
-	"dependencies": {
-		"svelte-local-storage-store": "^0.4.0"
-	}
+	"type": "module"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,15 +20,11 @@ specifiers:
   publint: ^0.1.9
   svelte: ^3.54.0
   svelte-check: ^3.0.1
-  svelte-local-storage-store: ^0.4.0
   tailwindcss: ^3.2.7
   tslib: ^2.4.1
   typescript: ^4.9.3
   vite: ^4.0.0
   vitest: ^0.25.3
-
-dependencies:
-  svelte-local-storage-store: 0.4.0_svelte@3.55.1
 
 devDependencies:
   '@playwright/test': 1.31.1
@@ -2040,15 +2036,6 @@ packages:
       svelte: 3.55.1
     dev: true
 
-  /svelte-local-storage-store/0.4.0_svelte@3.55.1:
-    resolution: {integrity: sha512-ctPykTt4S3BE5bF0mfV0jKiUR1qlmqLvnAkQvYHLeb9wRyO1MdIFDVI23X+TZEFleATHkTaOpYZswIvf3b2tWA==}
-    engines: {node: '>=0.14'}
-    peerDependencies:
-      svelte: ^3.48.0
-    dependencies:
-      svelte: 3.55.1
-    dev: false
-
   /svelte-preprocess/5.0.1_k4bhxdknaltjvjwprbm23edr5q:
     resolution: {integrity: sha512-0HXyhCoc9rsW4zGOgtInylC6qj259E1hpFnJMJWTf+aIfeqh4O/QHT31KT2hvPEqQfdjmqBR/kO2JDkkciBLrQ==}
     engines: {node: '>= 14.10.0'}
@@ -2101,6 +2088,7 @@ packages:
   /svelte/3.55.1:
     resolution: {integrity: sha512-S+87/P0Ve67HxKkEV23iCdAh/SX1xiSfjF1HOglno/YTbSTW7RniICMCofWGdJJbdjw3S+0PfFb1JtGfTXE0oQ==}
     engines: {node: '>= 8'}
+    dev: true
 
   /svelte2tsx/0.6.2_4x7phaipmicbaooxtnresslofa:
     resolution: {integrity: sha512-0ircYY2/jMOfistf+iq8fVHERnu1i90nku56c78+btC8svyafsc3OjOV37LDEOV7buqYY1Rv/uy03eMxhopH2Q==}


### PR DESCRIPTION
i think `svelte-local-storage-store` must be set on  peerDependecies. [check this](https://nodejs.org/es/blog/npm/peer-dependencies/) 

and no more duplicate if user install svelte-local-storage-store too